### PR TITLE
fix: refresh multiple contracts, statistic id invalid

### DIFF
--- a/custom_components/aigues_barcelona/manifest.json
+++ b/custom_components/aigues_barcelona/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/duhow/hass-aigues-barcelona/issues",
   "requirements": [],
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/custom_components/aigues_barcelona/sensor.py
+++ b/custom_components/aigues_barcelona/sensor.py
@@ -236,7 +236,7 @@ class ContadorAgua(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._attr_name = f"Contador {coordinator.name}"
+        self._attr_name = f"Contador {coordinator.id}"
         self._attr_unique_id = coordinator.id
         self._attr_icon = "mdi:water-pump"
         self._attr_has_entity_name = True

--- a/custom_components/aigues_barcelona/sensor.py
+++ b/custom_components/aigues_barcelona/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.core import CoreState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import TimestampDataUpdateCoordinator
 
 from .api import AiguesApiClient
 from .const import API_ERROR_TOKEN_REVOKED
@@ -84,7 +84,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
     return True
 
 
-class ContratoAgua(DataUpdateCoordinator):
+class ContratoAgua(TimestampDataUpdateCoordinator):
     def __init__(
         self,
         hass: HomeAssistant,

--- a/custom_components/aigues_barcelona/sensor.py
+++ b/custom_components/aigues_barcelona/sensor.py
@@ -99,6 +99,7 @@ class ContratoAgua(TimestampDataUpdateCoordinator):
 
         self.contract = contract.upper()
         self.id = contract.lower()
+        self.internal_sensor_id = f"sensor.contador_{self.id}"
 
         if not hass.data[DOMAIN].get(self.contract):
             # init data shared store
@@ -176,7 +177,7 @@ class ContratoAgua(TimestampDataUpdateCoordinator):
         to_clear = [
             x["statistic_id"]
             for x in all_ids
-            if x["statistic_id"].startswith(f"sensor.contador_{self.contract}")
+            if x["statistic_id"].startswith(self.internal_sensor_id)
         ]
 
         if to_clear:
@@ -218,7 +219,7 @@ class ContratoAgua(TimestampDataUpdateCoordinator):
             "has_sum": True,
             "name": None,
             "source": "recorder",  # required
-            "statistic_id": f"sensor.contador_{self.contract}",
+            "statistic_id": self.internal_sensor_id,
             "unit_of_measurement": UnitOfVolume.CUBIC_METERS,
         }
         # _LOGGER.debug(f"Adding metric: {metadata} {stats}")

--- a/custom_components/aigues_barcelona/sensor.py
+++ b/custom_components/aigues_barcelona/sensor.py
@@ -151,7 +151,7 @@ class ContratoAgua(TimestampDataUpdateCoordinator):
             _LOGGER.error("Token has expired, cannot check consumptions.")
             raise ConfigEntryAuthFailed from exp
         except Exception as exp:
-            _LOGGER.error("error while getting data: %s", exp)
+            self.async_set_update_error(exp)
             if API_ERROR_TOKEN_REVOKED in str(exp):
                 raise ConfigEntryAuthFailed from exp
 


### PR DESCRIPTION
Varios arreglos:
- El `statistic_id` era erroneo, solo afecta a contractos que tengan alguna letra (porque se buscaba en MAYUS y había que almacenarlo en minus).
- Trigger de `DataUpdateCoordinator` sólo se lanzaba para el último contrato creado, afecta a usuarios con más de 1 contrato.