### PR TITLE
feat: add User Agent to all requests

### DIFF
--- a/custom_components/aigues_barcelona/api.py
+++ b/custom_components/aigues_barcelona/api.py
@@ -7,6 +7,7 @@ import requests
 
 from .const import API_COOKIE_TOKEN
 from .const import API_HOST
+from .version import VERSION
 
 TIMEOUT = 60
 
@@ -27,6 +28,7 @@ class AiguesApiClient:
             "Ocp-Apim-Subscription-Key": "3cca6060fee14bffa3450b19941bd954",
             "Ocp-Apim-Trace": "false",
             "Content-Type": "application/json; charset=UTF-8",
+            "User-Agent": f"hass-aigues-barcelona/{VERSION} (Home Assistant)",
         }
         self._username = username
         self._password = password

--- a/custom_components/aigues_barcelona/manifest.json
+++ b/custom_components/aigues_barcelona/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/duhow/hass-aigues-barcelona/issues",
   "requirements": [],
-  "version": "0.4.3"
+  "version": "0.4.4"
 }

--- a/custom_components/aigues_barcelona/version.py
+++ b/custom_components/aigues_barcelona/version.py
@@ -1,0 +1,6 @@
+import json
+
+with open("manifest.json") as f:
+  manifest = json.load(f)
+
+VERSION = manifest.get("version", "0.0.0")

--- a/custom_components/aigues_barcelona/version.py
+++ b/custom_components/aigues_barcelona/version.py
@@ -1,6 +1,10 @@
 import json
+import os
 
-with open("manifest.json") as f:
-  manifest = json.load(f)
+try:
+    with open(os.path.join(os.path.dirname(__file__), "manifest.json")) as f:
+        manifest = json.load(f)
+except FileNotFoundError:
+    manifest = {}
 
 VERSION = manifest.get("version", "0.0.0")


### PR DESCRIPTION
Identifica las peticiones realizadas a Aigües de Barcelona conforme que están realizadas por esta integración.

La intención de enviar esto, es para demostrarles la cantidad de gente que utiliza esta integración, y estamos interesados en que funcione como queremos... 😌 

---

PS: Si alguien de **Aigües de Barcelona** lee esto, por favor poneros en contacto conmigo para llegar a alguna solución en cuanto al captcha del login #5 🙏🏻 . (idealmente este `User-Agent` podría servir como excepción de momento)